### PR TITLE
allow underscores to emails, add tests to cover

### DIFF
--- a/emailAddress_test.go
+++ b/emailAddress_test.go
@@ -25,6 +25,22 @@ func TestEmailAddress_Validate(t *testing.T) {
 			err:          nil,
 		},
 		{
+			emailAddress: "John_Doe@example.com",
+			err:          nil,
+		},
+		{
+			emailAddress: "John__Doe@example.com",
+			err:          nil,
+		},
+		{
+			emailAddress: "_John_Doe@example.com",
+			err:          nil,
+		},
+		{
+			emailAddress: "John_Doe_@example.com",
+			err:          nil,
+		},
+		{
 			emailAddress: "engineering@hatchifyco",
 			err:          errors.Error("\"hatchifyco\" does not have a valid TLD"),
 		},

--- a/utils.go
+++ b/utils.go
@@ -114,6 +114,7 @@ func isDigit(r rune) (ok bool) {
 func isAllowedSpecialChar(r rune) (ok bool) {
 	switch r {
 	case '.':
+	case '_':
 
 	default:
 		return false


### PR DESCRIPTION
This pr adds the `'_'` rune to the `isAllowedSpecialChar`

This function is called through out the application to validate emails. Right now this only accepts `'.'` however product has asked for emails with underscores to be added to allowed email addresses.

This PR should satisfy the requirement of https://hatchapp.atlassian.net/browse/HV2-1538